### PR TITLE
removed leading slashes from tf frames for hydro

### DIFF
--- a/launch/kinect_frames.launch
+++ b/launch/kinect_frames.launch
@@ -9,13 +9,13 @@
   <arg name="optical_rotate" value="0 0 0 -$(arg pi/2) 0 -$(arg pi/2)" />
 
   <node pkg="tf" type="static_transform_publisher" name="$(arg camera)_base_link"
-        args="0 -0.02  0 0 0 0  /$(arg camera)_link /$(arg camera)_depth_frame 100" />  
+        args="0 -0.02  0 0 0 0  $(arg camera)_link $(arg camera)_depth_frame 100" />  
   <node pkg="tf" type="static_transform_publisher" name="$(arg camera)_base_link1"
-        args="0 -0.045 0 0 0 0  /$(arg camera)_link /$(arg camera)_rgb_frame 100" />  
+        args="0 -0.045 0 0 0 0  $(arg camera)_link $(arg camera)_rgb_frame 100" />  
   <node pkg="tf" type="static_transform_publisher" name="$(arg camera)_base_link2"
-        args="$(arg optical_rotate) /$(arg camera)_depth_frame /$(arg camera)_depth_optical_frame  100" />  
+        args="$(arg optical_rotate) $(arg camera)_depth_frame $(arg camera)_depth_optical_frame  100" />  
   <node pkg="tf" type="static_transform_publisher" name="$(arg camera)_base_link3"
-        args="$(arg optical_rotate) /$(arg camera)_rgb_frame /$(arg camera)_rgb_optical_frame 100" />  
+        args="$(arg optical_rotate) $(arg camera)_rgb_frame $(arg camera)_rgb_optical_frame 100" />  
 </launch>
 
 <!-- TODO Could instead store these in camera_pose_calibration format for consistency

--- a/launch/openni2.launch
+++ b/launch/openni2.launch
@@ -4,8 +4,8 @@
   <!-- "camera" should uniquely identify the device. All topics are pushed down
        into the "camera" namespace, and it is prepended to tf frame ids. -->
   <arg name="camera" default="camera" />
-  <arg name="rgb_frame_id"   default="/$(arg camera)_rgb_optical_frame" />
-  <arg name="depth_frame_id" default="/$(arg camera)_depth_optical_frame" />
+  <arg name="rgb_frame_id"   default="$(arg camera)_rgb_optical_frame" />
+  <arg name="depth_frame_id" default="$(arg camera)_depth_optical_frame" />
 
   <arg name="device_id" default="#1" />
 


### PR DESCRIPTION
The hydro version of "tf" no longer supports having a leading slash "/" in tf frames.  There is some backwards compatibility but it is not universal.  Removing these leading slashes made things work better for me in Hydro.
