### PR TITLE
enables proper namespacing

### DIFF
--- a/launch/openni2.launch
+++ b/launch/openni2.launch
@@ -49,23 +49,23 @@
   <!-- Worker threads for the nodelet manager -->
   <arg name="num_worker_threads" default="4" />
 
-  <!-- Start nodelet manager in top-level namespace -->
-  <arg name="manager" value="$(arg camera)_nodelet_manager" />
-  <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
-  <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
-    <arg name="name" value="$(arg manager)" />
-    <arg name="debug" value="$(arg debug)" />
-    <arg name="machine" value="$(arg machine)" />
-    <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
-  </include>
-
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
+  
+	  <!-- Start nodelet manager -->
+	  <arg name="manager" value="$(arg camera)_nodelet_manager" />
+	  <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
+	  <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
+	    <arg name="name" value="$(arg manager)" />
+	    <arg name="debug" value="$(arg debug)" />
+	    <arg name="machine" value="$(arg machine)" />
+	    <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
+	  </include>
 
     <!-- Load driver -->
     <include if="$(arg load_driver)"
 	     file="$(find openni2_launch)/launch/includes/device.launch.xml">
-      <arg name="manager"               value="/$(arg manager)" /> <!-- Fully resolved -->
+      <arg name="manager"               value="$(arg manager)" />
       <arg name="device_id"             value="$(arg device_id)" />
       <arg name="rgb_frame_id"          value="$(arg rgb_frame_id)" />
       <arg name="depth_frame_id"        value="$(arg depth_frame_id)" />
@@ -79,7 +79,7 @@
 
     <!-- Load standard constellation of processing nodelets -->
     <include file="$(find rgbd_launch)/launch/includes/processing.launch.xml">
-      <arg name="manager"               value="/$(arg manager)" /> <!-- Fully resolved -->
+      <arg name="manager"               value="$(arg manager)" />
       <arg name="rgb"                   value="$(arg rgb)" />
       <arg name="ir"                    value="$(arg ir)" />
       <arg name="depth"                 value="$(arg depth)" />


### PR DESCRIPTION
This is similar to https://github.com/ros-drivers/openni_launch/issues/2

Is there a specific reason why this hasn't been adopted for openni2_launch or has this just been missed?
