### PR TITLE
Add tf_prefix same as openni

### DIFF
--- a/launch/openni2.launch
+++ b/launch/openni2.launch
@@ -4,8 +4,9 @@
   <!-- "camera" should uniquely identify the device. All topics are pushed down
        into the "camera" namespace, and it is prepended to tf frame ids. -->
   <arg name="camera" default="camera" />
-  <arg name="rgb_frame_id"   default="$(arg camera)_rgb_optical_frame" />
-  <arg name="depth_frame_id" default="$(arg camera)_depth_optical_frame" />
+  <arg name="tf_prefix" default="" />
+  <arg name="rgb_frame_id"   default="$(arg tf_prefix)/$(arg camera)_rgb_optical_frame" />
+  <arg name="depth_frame_id" default="$(arg tf_prefix)/$(arg camera)_depth_optical_frame" />
 
   <!-- device_id can have the following formats:
          "#1"  : the first device found
@@ -115,6 +116,7 @@
   <include if="$(arg publish_tf)"
 	   file="$(find rgbd_launch)/launch/kinect_frames.launch">
     <arg name="camera" value="$(arg camera)" />
+    <arg name="tf_prefix" value="$(arg tf_prefix)" />
   </include>
 
 </launch>


### PR DESCRIPTION
Hi,

The launch seems to be missing the tf_prefix option compared with openni, which is still supported by the rgbd_launch code. Patch adds it.

Was it removed on purpose? Adding this back lets me switch between openni_launch and openni2_launch without having to modify anything or come with new tf naming.

Cheers,
mark
