### PR TITLE
Force device_id to string type

### DIFF
--- a/launch/includes/device.launch.xml
+++ b/launch/includes/device.launch.xml
@@ -28,7 +28,7 @@
   <node pkg="nodelet" type="nodelet" name="driver"
         args="load openni2_camera/OpenNI2DriverNodelet $(arg manager)"
 	    respawn="$(arg respawn)">
-    <param name="device_id" value="$(arg device_id)" />
+    <param name="device_id" type="str" value="$(arg device_id)" />
     <param name="rgb_camera_info_url"   value="$(arg rgb_camera_info_url)" />
     <param name="depth_camera_info_url" value="$(arg depth_camera_info_url)" />
     <param name="rgb_frame_id"   value="$(arg rgb_frame_id)" />


### PR DESCRIPTION
device_id might look like an integer. in that case, getParam()
doesn't want to parse the param as a string for some reason (not
sure if this is by design).

This patch works around that issue.
