### PR TITLE
openni2_launch: disable bonding if respawn argument is false

### DIFF
--- a/launch/includes/device.launch.xml
+++ b/launch/includes/device.launch.xml
@@ -17,6 +17,8 @@
   <arg name="auto_white_balance" default="true" />
 
   <arg name="respawn" default="false" />
+  <arg     if="$(arg respawn)" name="bond" value="" />
+  <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
 
   <!-- Remapping arguments -->
   <arg name="rgb"              default="rgb" />
@@ -26,7 +28,7 @@
 
   <!-- Driver nodelet -->
   <node pkg="nodelet" type="nodelet" name="driver"
-        args="load openni2_camera/OpenNI2DriverNodelet $(arg manager)"
+        args="load openni2_camera/OpenNI2DriverNodelet $(arg manager) $(arg bond)"
 	    respawn="$(arg respawn)">
     <param name="device_id" type="str" value="$(arg device_id)" />
     <param name="rgb_camera_info_url"   value="$(arg rgb_camera_info_url)" />


### PR DESCRIPTION
This PR applies the patch from https://github.com/ros-drivers/rgbd_launch/commit/3bf8500439dfbf0f250387ddbd8de3140f1526ab to the driver nodelet, which adds the `--no-bond` argument to the nodelet loader if the the `respawn` argument is false.

Bonding can lead to unwanted unloading of the driver nodelet, e.g. under high CPU load, and is not required unless respawning is enabled, too:

```
[ INFO] [1471437821.472071099]: Bond broken, exiting
[camera/driver-2] process has finished cleanly
log file: /home/intermodalics/.ros/log/d29412a8-6473-11e6-beda-000acd295ca5/camera-driver-2*.log
```
